### PR TITLE
Adjust recent selection behavior and update Android permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,4 +39,12 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 </manifest>

--- a/src/i18n/i18n.tsx
+++ b/src/i18n/i18n.tsx
@@ -98,6 +98,7 @@ const translations: Translations = {
     'recent.title': 'Riepilogo ultimi 30 giorni',
     'recent.description': 'Le note create negli ultimi 30 giorni.',
     'recent.empty': 'Nessuna nota negli ultimi 30 giorni.',
+    'recent.selectPrompt': 'Seleziona un giorno per vedere i dettagli della nota.',
 
     'onboarding.title': 'Configura la tua esperienza',
     'onboarding.description': 'Prima di iniziare, impostiamo i dati necessari per trascrivere e sintetizzare le note.',
@@ -209,6 +210,7 @@ const translations: Translations = {
     'recent.title': 'Last 30 Days',
     'recent.description': 'Notes created in the last 30 days.',
     'recent.empty': 'No notes in the last 30 days.',
+    'recent.selectPrompt': 'Select a day to view the note details.',
 
     'onboarding.title': 'Set up your experience',
     'onboarding.description': 'Let’s prepare the essentials to transcribe and summarise your voice notes.',

--- a/src/pages/Recent.tsx
+++ b/src/pages/Recent.tsx
@@ -55,8 +55,8 @@ const RecentPage = () => {
       return;
     }
 
-    if (selectedIndex < 0 || selectedIndex >= list.length) {
-      setSelectedIndex(0);
+    if (selectedIndex >= list.length) {
+      setSelectedIndex(-1);
     }
   }, [list.length, selectedIndex]);
 
@@ -82,7 +82,9 @@ const RecentPage = () => {
     : false;
 
   const hasTranscript = selectedEntry
-    ? selectedEntry.transcript && selectedEntry.transcript.trim().length > 0 && selectedEntry.transcript.trim() !== displayText.trim()
+    ? selectedEntry.transcript &&
+      selectedEntry.transcript.trim().length > 0 &&
+      selectedEntry.transcript.trim() !== displayText.trim()
     : false;
 
   return (
@@ -155,7 +157,7 @@ const RecentPage = () => {
                       )}
                     </>
                   ) : (
-                    <div className="text-sm text-muted-foreground">{t('recent.empty')}</div>
+                    <div className="text-sm text-muted-foreground">{t('recent.selectPrompt')}</div>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- prevent the Recent page from auto-opening entries and show a prompt until a day is selected
- add translation strings for the new Recent page prompt in both Italian and English
- expand Android manifest permissions to cover audio recording and media access scenarios

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2de3e78b883219e5af752a2ec279d