### PR TITLE
Rename Android app to Audio Diary

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">jade-griffin-dive</string>
-    <string name="title_activity_main">jade-griffin-dive</string>
+    <string name="app_name">Audio Diary</string>
+    <string name="title_activity_main">Audio Diary</string>
     <string name="package_name">com.example.jadegriffindive</string>
     <string name="custom_url_scheme">com.example.jadegriffindive</string>
 </resources>


### PR DESCRIPTION
## Summary
- update the Android string resources so the app name shows "Audio Diary"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2e4551b1c8321832c7d8e34b53816