### PR TITLE
Rename app to Audio Diary and support audio uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Psychological Journal (Diario Psicologico)
+# Audio Diary (Audio Diario)
 
 <img width="1920" height="1080" alt="logo-orizzontale" src="https://github.com/user-attachments/assets/7157e9f6-6e78-4a63-9727-0e988fa656fd" />
 
@@ -20,10 +20,12 @@ Key highlights:
 
 - Audio notes and AI
   - Record audio in the browser (Web MediaRecorder)
+  - Upload existing audio files from your device
   - Transcribe with Whisper (`whisper-1`) using your OpenAI key
   - Summarize transcripts with GPT models (configurable)
   - Editable “System Prompt” to customize summaries’ tone and content
   - Delete a note’s audio (and all audios at once from Settings)
+  - Copy either the generated summary or full transcript into your note with one click
 
 - Export
   - Export all notes to JSON
@@ -112,6 +114,9 @@ Build an Android APK with Capacitor.
 
 Local (Android Studio):
 - Prereqs: Android Studio (SDK + build tools), Java 17.
+- Required permissions (already declared in `android/app/src/main/AndroidManifest.xml`):
+  - `RECORD_AUDIO` and `MODIFY_AUDIO_SETTINGS`
+  - `READ_MEDIA_AUDIO` (Android 13+) and legacy storage permissions for older devices
 - Steps:
   1. Install deps: `npm install`
   2. Build web: `npm run build`

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,6 +1,6 @@
 {
   "appId": "com.audiodiary.app",
-  "appName": "Psychological Journal",
+  "appName": "Audio Diary",
   "webDir": "dist",
   "bundledWebRuntime": false,
   "server": {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <title>Diario Psicologico</title>
+    <title>Audio Diario</title>
   </head>
 
   <body>

--- a/src/components/AudioControls.tsx
+++ b/src/components/AudioControls.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { Mic, Square, FileText, Sparkles, Loader2, Trash2, Pause, Play } from 'lucide-react';
+import { Mic, Square, FileText, Sparkles, Loader2, Trash2, Pause, Play, Upload } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Settings } from './SettingsDialog';
 import { transcribeAudio, summarizeText } from '@/services/openai';
@@ -21,6 +21,7 @@ interface AudioControlsProps {
   settings: Settings;
   audioFile: File | undefined;
   onCopySummaryToNote?: () => void;
+  onCopyTranscriptToNote?: () => void;
 }
 
 const AudioControls: React.FC<AudioControlsProps> = ({
@@ -32,6 +33,7 @@ const AudioControls: React.FC<AudioControlsProps> = ({
   settings,
   audioFile,
   onCopySummaryToNote,
+  onCopyTranscriptToNote,
 }) => {
   const { t, lang } = useI18n();
   const [isRecording, setIsRecording] = useState(false);
@@ -41,6 +43,24 @@ const AudioControls: React.FC<AudioControlsProps> = ({
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const manualFileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const processSelectedFile = (file?: File) => {
+    if (!file) return;
+    try {
+      const url = URL.createObjectURL(file);
+      onUpdate({ audioUrl: url, audioFile: file, transcript: undefined, summary: undefined });
+    } catch (err: unknown) {
+      console.error('Failed to load selected audio file', err);
+      showError(t('audio.micDenied'));
+    } finally {
+      setIsRecording(false);
+      setIsPaused(false);
+      setCanPause(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      if (manualFileInputRef.current) manualFileInputRef.current.value = '';
+    }
+  };
 
   const isMediaRecorderSupported =
     typeof window !== 'undefined'
@@ -180,20 +200,18 @@ const AudioControls: React.FC<AudioControlsProps> = ({
   };
 
   const handleFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+    processSelectedFile(e.target.files?.[0]);
+  };
+
+  const handleManualFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    processSelectedFile(e.target.files?.[0]);
+  };
+
+  const handleUploadClick = () => {
     try {
-      const url = URL.createObjectURL(file);
-      onUpdate({ audioUrl: url, audioFile: file, transcript: undefined, summary: undefined });
-    } catch (err: unknown) {
-      console.error('Failed to load selected audio file', err);
-      showError(t('audio.micDenied'));
-    } finally {
-      setIsRecording(false);
-      setIsPaused(false);
-      setCanPause(false);
-      // reset input so selecting the same file again triggers change
-      if (fileInputRef.current) fileInputRef.current.value = '';
+      manualFileInputRef.current?.click();
+    } catch (error) {
+      console.error('Manual audio upload failed', error);
     }
   };
 
@@ -272,7 +290,14 @@ const AudioControls: React.FC<AudioControlsProps> = ({
           className="hidden"
           onChange={handleFileSelected}
         />
-        <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
+        <input
+          ref={manualFileInputRef}
+          type="file"
+          accept="audio/*"
+          className="hidden"
+          onChange={handleManualFileSelected}
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-5 gap-2">
           <Button onClick={handleToggleRecording} disabled={disabled || isLoading !== null} variant={isRecording ? "destructive" : "outline"}>
             {isRecording ? (
               <><Square className="mr-2 h-4 w-4" /> {t('audio.stop')}</>
@@ -290,6 +315,10 @@ const AudioControls: React.FC<AudioControlsProps> = ({
             ) : (
               <><Pause className="mr-2 h-4 w-4" /> {t('audio.pause')}</>
             )}
+          </Button>
+          <Button onClick={handleUploadClick} disabled={disabled || isLoading !== null} variant="secondary">
+            <Upload className="mr-2 h-4 w-4" />
+            {t('audio.upload')}
           </Button>
           <Button onClick={handleTranscribe} disabled={!audioFile || isLoading !== null || disabled}>
             {isLoading === 'transcribe' ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <FileText className="mr-2 h-4 w-4" />}
@@ -316,22 +345,13 @@ const AudioControls: React.FC<AudioControlsProps> = ({
                 <Trash2 className="h-4 w-4" />
               </Button>
             </div>
-            <div className="mt-2">
-              <Button
-                type="button"
-                onClick={() => onCopySummaryToNote && onCopySummaryToNote()}
-                disabled={disabled || !summary}
-              >
-                {t('daily.copySummaryToNote')}
-              </Button>
-            </div>
           </div>
         )}
 
         {transcript && (
           <div>
             <Label className="text-sm font-medium mb-1">{t('audio.transcriptLabel')}</Label>
-            <Textarea value={transcript} readOnly className="bg-background mt-1" rows={4} />
+            <Textarea value={transcript} readOnly className="bg-background mt-1 min-h-[240px] text-base resize-y" rows={10} />
           </div>
         )}
 
@@ -339,6 +359,29 @@ const AudioControls: React.FC<AudioControlsProps> = ({
           <div>
             <Label className="text-sm font-medium mb-1">{t('audio.summaryLabel')}</Label>
             <Textarea value={summary} readOnly className="bg-background mt-1" rows={3} />
+          </div>
+        )}
+
+        {(transcript || summary) && (
+          <div className="flex flex-wrap justify-end gap-2">
+            {transcript && (
+              <Button
+                type="button"
+                onClick={() => onCopyTranscriptToNote && onCopyTranscriptToNote()}
+                disabled={disabled}
+              >
+                {t('daily.copyTranscriptToNote')}
+              </Button>
+            )}
+            {summary && (
+              <Button
+                type="button"
+                onClick={() => onCopySummaryToNote && onCopySummaryToNote()}
+                disabled={disabled}
+              >
+                {t('daily.copySummaryToNote')}
+              </Button>
+            )}
           </div>
         )}
       </CardContent>

--- a/src/i18n/i18n.tsx
+++ b/src/i18n/i18n.tsx
@@ -9,7 +9,7 @@ type Translations = Record<Lang, Dict>;
 
 const translations: Translations = {
   it: {
-    'app.title': 'Diario Psicologico',
+    'app.title': 'Audio Diario',
     'header.subtitle': 'Le tue riflessioni quotidiane, in un unico posto.',
     'header.export': 'Esporta',
     'header.settings': 'Impostazioni',
@@ -37,7 +37,8 @@ const translations: Translations = {
     'daily.saveNote': 'Salva Nota',
     'daily.saveEntry': 'Salva Voce',
     'daily.clear': 'Pulisci',
-    'daily.copySummaryToNote': 'Salva in Nota',
+    'daily.copySummaryToNote': 'Salva sintesi in Nota',
+    'daily.copyTranscriptToNote': 'Salva trascrizione in Nota',
 
     'stats.title': 'Statistiche',
     'stats.totalEntries': 'Voci totali:',
@@ -55,6 +56,7 @@ const translations: Translations = {
     'audio.resume': 'Riprendi',
     'audio.transcribe': 'Trascrivi',
     'audio.summarize': 'Sintetizza',
+    'audio.upload': 'Carica audio',
     'audio.recordingLabel': 'Registrazione:',
     'audio.transcriptLabel': 'Trascrizione:',
     'audio.summaryLabel': 'Sintesi Automatica:',
@@ -88,7 +90,7 @@ const translations: Translations = {
     'export.cancel': 'Annulla',
     'export.includeSensitive': 'Includi contenuti/testi sensibili in export',
 
-    'ics.calendarName': 'Diario Psicologico',
+    'ics.calendarName': 'Audio Diario',
     'ics.rating': 'Valutazione',
     'ics.none': 'Nessuna',
     'ics.content': 'Contenuto',
@@ -105,7 +107,7 @@ const translations: Translations = {
     'onboarding.next': 'Avanti',
     'onboarding.back': 'Indietro',
     'onboarding.finish': 'Conferma e salva',
-    'onboarding.introTitle': 'Benvenuto in Diario Psicologico',
+    'onboarding.introTitle': 'Benvenuto in Audio Diario',
     "onboarding.introDescription": "Per sfruttare appieno l'app abbiamo bisogno di alcune informazioni.",
     'onboarding.introPoint1': 'Inserisci la tua chiave API di OpenAI: rimane salvata solo nel tuo browser.',
     'onboarding.introPoint2': 'Personalizza il prompt di sistema che guiderà le sintesi generate da OpenAI.',
@@ -121,7 +123,7 @@ const translations: Translations = {
     'onboarding.completed': 'Impostazioni iniziali salvate! Puoi aggiornarle dalle Impostazioni.',
   },
   en: {
-    'app.title': 'Psychological Journal',
+    'app.title': 'Audio Diary',
     'header.subtitle': 'Your daily reflections, in one place.',
     'header.export': 'Export',
     'header.settings': 'Settings',
@@ -149,7 +151,8 @@ const translations: Translations = {
     'daily.saveNote': 'Save Note',
     'daily.saveEntry': 'Save Entry',
     'daily.clear': 'Clear',
-    'daily.copySummaryToNote': 'Save to Note',
+    'daily.copySummaryToNote': 'Save summary to Note',
+    'daily.copyTranscriptToNote': 'Save transcript to Note',
 
     'stats.title': 'Statistics',
     'stats.totalEntries': 'Total entries:',
@@ -167,6 +170,7 @@ const translations: Translations = {
     'audio.resume': 'Resume',
     'audio.transcribe': 'Transcribe',
     'audio.summarize': 'Summarize',
+    'audio.upload': 'Upload audio',
     'audio.recordingLabel': 'Recording:',
     'audio.transcriptLabel': 'Transcript:',
     'audio.summaryLabel': 'Automatic Summary:',
@@ -200,7 +204,7 @@ const translations: Translations = {
     'export.cancel': 'Cancel',
     'export.includeSensitive': 'Include sensitive content/texts in export',
 
-    'ics.calendarName': 'Psychological Journal',
+    'ics.calendarName': 'Audio Diary',
     'ics.rating': 'Rating',
     'ics.none': 'None',
     'ics.content': 'Content',
@@ -217,7 +221,7 @@ const translations: Translations = {
     'onboarding.next': 'Next',
     'onboarding.back': 'Back',
     'onboarding.finish': 'Save and continue',
-    'onboarding.introTitle': 'Welcome to Psychological Journal',
+    'onboarding.introTitle': 'Welcome to Audio Diary',
     'onboarding.introDescription': 'We just need a couple of details before you start recording your reflections.',
     'onboarding.introPoint1': 'Add your OpenAI API key — it will remain stored locally in your browser.',
     'onboarding.introPoint2': 'Review or customise the system prompt that drives the automatic summaries.',

--- a/src/pages/DailyJournal.tsx
+++ b/src/pages/DailyJournal.tsx
@@ -606,6 +606,7 @@ const DailyJournal = () => {
                 settings={settings}
                 audioFile={currentAudioFile}
                 onCopySummaryToNote={() => { const s = (currentSummary || '').trim(); if (!s) return; setCurrentContent(s); setContentAutoFilled(true); }}
+                onCopyTranscriptToNote={() => { const tr = (currentTranscript || '').trim(); if (!tr) return; setCurrentContent(tr); setContentAutoFilled(true); }}
               />
 
               <div className="flex gap-4">

--- a/src/utils/export-utils.ts
+++ b/src/utils/export-utils.ts
@@ -19,8 +19,8 @@ export const exportToJson = (entries: JournalEntryForExport[]): string => {
 export const exportToIcs = async (entries: JournalEntryForExport[], lang: Lang = 'it'): Promise<string> => {
   const t = (key: 'calendarName' | 'rating' | 'none' | 'content' | 'transcript' | 'summary') => {
     const map = {
-      it: { calendarName: 'Diario Psicologico', rating: 'Valutazione', none: 'Nessuna', content: 'Contenuto', transcript: 'Trascrizione', summary: 'Sintesi' },
-      en: { calendarName: 'Psychological Journal', rating: 'Rating', none: 'None', content: 'Content', transcript: 'Transcript', summary: 'Summary' },
+      it: { calendarName: 'Audio Diario', rating: 'Valutazione', none: 'Nessuna', content: 'Contenuto', transcript: 'Trascrizione', summary: 'Sintesi' },
+      en: { calendarName: 'Audio Diary', rating: 'Rating', none: 'None', content: 'Content', transcript: 'Transcript', summary: 'Summary' },
     } as const;
     return map[lang][key];
   };


### PR DESCRIPTION
## Summary
- update the app title and branding strings to "Audio Diary" across the UI, web entrypoint, and Capacitor config
- add an audio upload workflow with a dedicated button, larger transcript view, and the ability to copy transcripts into notes
- refresh documentation and export labels to reflect the new name and document Android audio permissions

## Testing
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dea8c35dd48321b2dec7958c3b19ab