### PR TITLE
Add goals overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Key highlights:
 - Mobile‑friendly: tuned header layout and safe‑area padding for Android/iOS.
 - i18n: English and Italian with language switching in the UI.
 
+## Goals
+
+The goal is to create an Android app that lets you upload or record an audio file and obtain a transcription using your OpenAI API key and the Whisper model. Afterwards you can optionally generate a summary driven by a customizable prompt when desired.
+
+Manual audio file uploads are now supported alongside in-app recording.
+
 ## Features
 
 - Daily notes


### PR DESCRIPTION
## Summary
- add a Goals section to the README outlining the app's focus on audio transcription and summarization with Whisper
- note that manual audio file uploads are supported in addition to in-app recording

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e2c34d9a0c8321b709006955cf0a5a